### PR TITLE
Fix issue where start-docker cmd fails

### DIFF
--- a/ecs/buildspec-earthly.yml
+++ b/ecs/buildspec-earthly.yml
@@ -70,7 +70,7 @@ phases:
       - COMMIT_HASH=$CODEBUILD_RESOLVED_SOURCE_VERSION
       - IMAGE_TAG=${COMMIT_HASH:=latest}
       
-        # Make the scripts in bin folder are exeecutable
+      # Ensure that scripts are executable
       - chmod u+x rel/overlays/bin/*
   build:
     commands:

--- a/ecs/buildspec-earthly.yml
+++ b/ecs/buildspec-earthly.yml
@@ -69,6 +69,9 @@ phases:
       # - COMMIT_HASH=$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | cut -c 1-7)
       - COMMIT_HASH=$CODEBUILD_RESOLVED_SOURCE_VERSION
       - IMAGE_TAG=${COMMIT_HASH:=latest}
+      
+        # Make the scripts in bin folder are exeecutable
+      - chmod u+x rel/overlays/bin/*
   build:
     commands:
       # Scan app source for vulnerabilities


### PR DESCRIPTION
When building an Alpine image, the start-docker CMD is failing with permissions error.  This change makes sure that the files have execute bit set before copying the files.